### PR TITLE
Add `no_std` support.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,21 @@
 [package]
 name = "url-parse"
 version = "1.0.1"
-description = "🔗 A Rust library for parsing URLs."
+description = "🔗 A Rust library for parsing URLs. (no_std fork)"
 
 categories = ["parser-implementations", "web-programming", "encoding"]
 edition = "2021"
 keywords = ["parser", "url"]
 license = "MIT"
-repository = "https://github.com/mihaigalos/url-parse"
+repository = "https://github.com/notsatvrn/url-parse"
 
 [dependencies]
-regex = "1.7.0"
+hashbrown = { version = "0.13.1", optional = true }
+regex = { version = "1.7.0", optional = true }
+safe-regex = { version = "0.2.5", optional = true }
+
+[features]
+default = ["std"]
+
+std = ["dep:regex"]
+alloc = ["dep:hashbrown", "dep:safe-regex"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "url-parse"
 version = "1.0.1"
-description = "🔗 A Rust library for parsing URLs. (no_std fork)"
+description = "🔗 A Rust library for parsing URLs."
 
 categories = ["parser-implementations", "web-programming", "encoding"]
 edition = "2021"
 keywords = ["parser", "url"]
 license = "MIT"
-repository = "https://github.com/notsatvrn/url-parse"
+repository = "https://github.com/mihaigalos/url-parse"
 
 [dependencies]
 hashbrown = { version = "0.13.1", optional = true }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# url-parse
+# url-parse (`no_std` fork)
 
 [![CI](https://github.com/mihaigalos/url-parse/actions/workflows/ci.yaml/badge.svg)](https://github.com/mihaigalos/url-parse/actions/workflows/ci.yaml)
 [![CD](https://github.com/mihaigalos/url-parse/actions/workflows/cd.yaml/badge.svg)](https://github.com/mihaigalos/url-parse/actions/workflows/cd.yaml)
@@ -48,13 +48,13 @@ assert_eq!(
 
 ### Custom schemes
 
-Passing a `Some(HashMap)` to `Parser::new()` can be used to create custom schemes.
+Passing a `Some(PortMap)` to `Parser::new()` can be used to create custom schemes.
 
 The hashmap is a key,value pair representing the scheme name (key) to a port and description mapping (value).
 
 ```rust
 let input = "myschema://user:pass@example.co.uk/path/to/file.txt";
-let mut myport_mappings = HashMap::new();
+let mut myport_mappings = PortMap::new();
 myport_mappings.insert("myschema", (8888, "My custom schema"));
 let result = Parser::new(Some(myport_mappings)).parse(input).unwrap();
 assert_eq!(

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# url-parse (`no_std` fork)
+# url-parse
 
 [![CI](https://github.com/mihaigalos/url-parse/actions/workflows/ci.yaml/badge.svg)](https://github.com/mihaigalos/url-parse/actions/workflows/ci.yaml)
 [![CD](https://github.com/mihaigalos/url-parse/actions/workflows/cd.yaml/badge.svg)](https://github.com/mihaigalos/url-parse/actions/workflows/cd.yaml)

--- a/src/core/defaults.rs
+++ b/src/core/defaults.rs
@@ -1,9 +1,9 @@
-use std::collections::HashMap;
+use crate::core::PortMap;
 
 /// Get the default port mappings for well-known ports.
 /// This is a convenience function to create a Parser object (via `Parser::new()`) and pass it defaults.
-pub fn default_port_mappings() -> HashMap<&'static str, (u32, &'static str)> {
-    let mut m = HashMap::new();
+pub fn default_port_mappings() -> PortMap {
+    let mut m = PortMap::new();
     m.insert("ftp", (21, "File Transfer Protocol"));
     m.insert("http", (80, "Hypertext Transfer Protocol"));
     m.insert("https", (443, "Hypertext Transfer Protocol Secure"));

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -9,14 +9,19 @@ mod scheme;
 pub mod scheme_separator;
 
 pub mod global;
-use crate::core::defaults::default_port_mappings;
 use crate::error::ParseError;
 use crate::url::Url;
 
-use std::collections::HashMap;
+use crate::HashMap;
+
+use alloc::string::ToString;
+
+pub use defaults::default_port_mappings;
+
+pub type PortMap = HashMap<&'static str, (u32, &'static str)>;
 
 pub struct Parser {
-    port_mappings: HashMap<&'static str, (u32, &'static str)>,
+    port_mappings: PortMap,
 }
 
 impl Parser {
@@ -28,7 +33,7 @@ impl Parser {
     /// use url_parse::core::Parser;
     /// let parser = Parser::new(None);
     /// ```
-    pub fn new(port_mappings: Option<HashMap<&'static str, (u32, &'static str)>>) -> Self {
+    pub fn new(port_mappings: Option<PortMap>) -> Self {
         Parser {
             port_mappings: port_mappings.unwrap_or_else(default_port_mappings),
         }
@@ -221,7 +226,7 @@ mod tests {
     #[test]
     fn test_parse_works_when_custom_port_mappings_full_login() {
         let input = "myschema://user:pass@example.co.uk/path/to/file.txt";
-        let mut myport_mappings = HashMap::new();
+        let mut myport_mappings = PortMap::new();
         myport_mappings.insert("myschema", (8888, "My custom schema"));
         let result = Parser::new(Some(myport_mappings)).parse(input).unwrap();
         assert_eq!(

--- a/src/core/path.rs
+++ b/src/core/path.rs
@@ -1,6 +1,8 @@
 use crate::core::Parser;
 use crate::utils::Utils;
 
+use alloc::vec::Vec;
+
 impl Parser {
     /// Extract the path as a vector from the url.
     ///

--- a/src/core/scheme.rs
+++ b/src/core/scheme.rs
@@ -1,5 +1,8 @@
 use crate::core::scheme_separator::SchemeSeparator;
 use crate::core::Parser;
+
+use alloc::vec::Vec;
+
 impl Parser {
     /// Extract the query from the url.
     ///
@@ -30,9 +33,7 @@ impl Parser {
 
         let split: Vec<&str> = input.split(':').collect();
         let scheme = self
-            .port_mappings
-            .iter()
-            .map(|(protocol, _)| protocol)
+            .port_mappings.keys()
             .find(|&protocol| &split[0] == protocol)?;
         Some((scheme, SchemeSeparator::Colon))
     }

--- a/src/core/scheme_separator.rs
+++ b/src/core/scheme_separator.rs
@@ -1,3 +1,5 @@
+use alloc::string::{String, ToString};
+
 #[derive(Debug, PartialEq, Eq)]
 pub enum SchemeSeparator {
     Colon,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,16 +31,15 @@ No current other crate with support for i.e. special schemes. The reasoning (i.e
  )
  ```
 
- Passing a Some(HashMap) to Parser::new() can be used to create custom schemes.
+ Passing a Some(PortMap) to Parser::new() can be used to create custom schemes.
 
  The hashmap is a key,value pair representing the scheme name (key) to a port and description mapping (value).
  # Example
  ```rust,no_run
- use std::collections::HashMap;
- use url_parse::core::Parser;
+ use url_parse::core::{Parser, PortMap};
  use url_parse::url::Url;
  let input = "myschema://user:pass@example.co.uk/path/to/file.txt";
- let mut myport_mappings = HashMap::new();
+ let mut myport_mappings = PortMap::new();
  myport_mappings.insert("myschema", (8888, "My custom schema"));
  let result = Parser::new(Some(myport_mappings)).parse(input).unwrap();
  assert_eq!(
@@ -63,6 +62,19 @@ No current other crate with support for i.e. special schemes. The reasoning (i.e
  )
  ```
 */
+
+#![no_std]
+
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std as alloc;
+
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+pub(crate) type HashMap<K, V> = hashbrown::HashMap<K, V>;
+#[cfg(feature = "std")]
+pub(crate) type HashMap<K, V> = alloc::collections::HashMap<K, V>;
+
 pub mod core;
 pub mod error;
 pub mod url;

--- a/src/url.rs
+++ b/src/url.rs
@@ -1,3 +1,7 @@
+use alloc::string::{String, ToString};
+use alloc::borrow::ToOwned;
+use alloc::vec::Vec;
+
 #[derive(Debug)]
 pub struct Url {
     pub scheme: Option<String>,
@@ -210,9 +214,9 @@ impl PartialEq for Url {
 }
 
 /// Display the serialization of this URL.
-impl std::fmt::Display for Url {
+impl alloc::fmt::Display for Url {
     #[inline]
-    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, fmt: &mut alloc::fmt::Formatter) -> Result<(), alloc::fmt::Error> {
         write!(fmt, "{:?}", self)
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,10 @@
 use crate::core::scheme_separator::SchemeSeparator;
 use crate::core::Parser;
-use std::collections::HashMap;
+use crate::HashMap;
+
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+
 pub struct Utils;
 
 impl Utils {


### PR DESCRIPTION
This PR adds support for use of this library in `no_std` environments.

It also defines a type for port mapping called `PortMap` which will use the proper `HashMap` implementation for the current environment, and makes `default_port_mappings` public at the root of `core`.