### PR TITLE
Implement std::error::Error for ParseError

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,13 @@
+use core::fmt::Display;
+
 #[derive(Debug)]
 pub enum ParseError {
-    UnknownError,
-    Ok,
 }
+ 
+impl Display for ParseError {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "ParseError")
+    }
+}
+
+impl std::error::Error for ParseError {}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,9 +1,8 @@
 use core::fmt::Display;
 
 #[derive(Debug)]
-pub enum ParseError {
-}
- 
+pub struct ParseError {}
+
 impl Display for ParseError {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         write!(f, "ParseError")
@@ -11,3 +10,10 @@ impl Display for ParseError {
 }
 
 impl std::error::Error for ParseError {}
+
+#[test]
+fn test_err_display() {
+    let e = ParseError {};
+    let x = format!("{e}");
+    assert_eq!(x, "ParseError")
+}


### PR DESCRIPTION
`ParseError` is never emitted, so the dead `enum` members are removed.

 By implementing `std::error::Error` for the error type the user is able to unwrap with a `?` and return a `Result<(),Box<dyn std::error::Error>>` without extra code.